### PR TITLE
 use directories and params for split segmentations instead of input/output

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -28,7 +28,8 @@ hemis = config['hemis']
 
 
 wildcard_constraints:
-    subject="[a-zA-Z0-9]+"
+    subject="[a-zA-Z0-9]+",
+    template="[a-zA-Z0-9]+"
 
 
 rule all:

--- a/Snakefile
+++ b/Snakefile
@@ -105,18 +105,21 @@ rule split_targets:
     input: 
         targets = 'diffparc/sub-{subject}/masks/lh_rh_targets_dwi.nii.gz',
     params:
-        target_nums = lambda wildcards: [str(i) for i in range(len(targets))]
-    output:
+        target_nums = lambda wildcards: [str(i) for i in range(len(targets))],
         target_seg = expand('diffparc/sub-{subject}/targets/{target}.nii.gz',target=targets,allow_missing=True)
+    output:
+        target_seg_dir = directory('diffparc/sub-{subject}/targets')
     singularity: config['singularity_neuroglia']
     log: 'logs/split_targets/sub-{subject}.log'
     threads: 32 
     group: 'pre_track'
     shell:
-        'parallel  --jobs {threads} fslmaths {input.targets} -thr {{1}} -uthr {{1}} -bin {{2}} &> {log} ::: {params.target_nums} :::+ {output.target_seg}'
+        'mkdir -p {output} && parallel  --jobs {threads} fslmaths {input.targets} -thr {{1}} -uthr {{1}} -bin {{2}} &> {log} ::: {params.target_nums} :::+ {params.target_seg}'
 
 rule gen_targets_txt:
     input:
+        target_seg_dir = 'diffparc/sub-{subject}/targets'
+    params:
         target_seg = expand('diffparc/sub-{subject}/targets/{target}.nii.gz',target=targets,allow_missing=True)
     output:
         target_txt = 'diffparc/sub-{subject}/target_images.txt'
@@ -124,7 +127,7 @@ rule gen_targets_txt:
     group: 'pre_track'
     run:
         f = open(output.target_txt,'w')
-        for s in input.target_seg:
+        for s in params.target_seg:
             f.write(f'{s}\n')
         f.close()
 
@@ -134,13 +137,13 @@ rule run_probtrack:
         seed_res = rules.resample_seed.output,
         target_txt = rules.gen_targets_txt.output,
         mask = 'diffparc/sub-{subject}/masks/brain_mask_dwi.nii.gz',
-        target_seg = expand('diffparc/sub-{subject}/targets/{target}.nii.gz',target=targets,allow_missing=True)
+        target_seg_dir = 'diffparc/sub-{subject}/targets'
     params:
         bedpost_merged = join(config['prepdwi_dir'],'bedpost','sub-{subject}','merged'),
         probtrack_opts = config['probtrack']['opts'],
-        probtrack_dir = 'diffparc/sub-{subject}/probtrack_{template}_{seed}_{hemi}'
+        out_target_seg = expand('diffparc/sub-{subject}/probtrack_{template}_{seed}_{hemi}/seeds_to_{target}.nii.gz',target=targets,allow_missing=True)
     output:
-        target_seg = expand('diffparc/sub-{subject}/probtrack_{template}_{seed}_{hemi}/seeds_to_{target}.nii.gz',target=targets,allow_missing=True)
+        probtrack_dir = directory('diffparc/sub-{subject}/probtrack_{template}_{seed}_{hemi}'),
     threads: 2
     resources: 
         mem_mb = 32000, 
@@ -148,47 +151,38 @@ rule run_probtrack:
         gpus = 1 #1 gpu
     log: 'logs/run_probtrack/{template}_sub-{subject}_{seed}_{hemi}.log'
     shell:
-        'probtrackx2_gpu --samples={params.bedpost_merged}  --mask={input.mask} --seed={input.seed_res} ' 
+        'mkdir -p {output.probtrack_dir} && probtrackx2_gpu --samples={params.bedpost_merged}  --mask={input.mask} --seed={input.seed_res} ' 
         '--targetmasks={input.target_txt} --seedref={input.seed_res} --nsamples={config[''probtrack''][''nsamples'']} ' 
-        '--dir={params.probtrack_dir} {params.probtrack_opts} -V 2  &> {log}'
+        '--dir={output.probtrack_dir} {params.probtrack_opts} -V 2  &> {log}'
 
-rule copy_ufile:
-    input:
-        ufile_nii = join(config['seed_seg_dir'],config['ufile_nii'])
-    output:
-        ufile_nii = 'diffparc/sub-{subject}/probtrack_{template}_{seed}_{hemi}/u_rc1msub-{subject}_to_template.nii',
-    shell: 'cp -v {input} {output}'
-
-rule prep_for_dartel_warp:
-    input:
-        connmap_3d = 'diffparc/sub-{subject}/probtrack_{template}_{seed}_{hemi}/seeds_to_{target}.nii.gz',
-    params:
-        connmap_unzip_prefix = 'diffparc/sub-{subject}/probtrack_{template}_{seed}_{hemi}/seeds_to_{target}_unzip',
-    output:
-        connmap_3d = 'diffparc/sub-{subject}/probtrack_{template}_{seed}_{hemi}/seeds_to_{target}_unzip.nii',
-    shell:
-        'cp -v {input.connmap_3d} {params.connmap_unzip_prefix}.nii.gz &&'
-        'gunzip {params.connmap_unzip_prefix}.nii.gz'
-        
-    
 rule transform_conn_to_template_dartel:
     input:
-        connmap_3d = 'diffparc/sub-{subject}/probtrack_{template}_{seed}_{hemi}/seeds_to_{target}_unzip.nii',
-        ufile_nii = 'diffparc/sub-{subject}/probtrack_{template}_{seed}_{hemi}/u_rc1msub-{subject}_to_template.nii'
+        connmap_dir = 'diffparc/sub-{subject}/probtrack_{template}_{seed}_{hemi}',
+        ufile_nii = join(config['seed_seg_dir'],config['ufile_nii'])
+    params:
+        in_connmap = expand('diffparc/sub-{subject}/probtrack_{template}_{seed}_{hemi}/seeds_to_{target}.nii.gz',target=targets,allow_missing=True),
+        unzip_connmap = expand('diffparc/sub-{subject}/probtrack_{template}_{seed}_{hemi}_warped/wseeds_to_{target}.nii',target=targets,allow_missing=True),
+        ufile_nii = 'diffparc/sub-{subject}/probtrack_{template}_{seed}_{hemi}_warped/u_rc1msub-{subject}_to_template.nii'
     output:
-        connmap_3d = 'diffparc/sub-{subject}/probtrack_{template}_{seed}_{hemi}/wseeds_to_{target}_unzip.nii',
+        warped_dir = directory('diffparc/sub-{subject}/probtrack_{template}_{seed}_{hemi}_warped')
     envmodules: 'matlab/2020a'
-    log: 'logs/transform_conn_to_template_dartel/sub-{subject}_{seed}_{hemi}_{template}/{target}.log'
+    threads: 32
+    resources:
+        mem_mb = 128000
+    log: 'logs/transform_conn_to_template_dartel/sub-{subject}_{seed}_{hemi}_{template}.log'
     group: 'post_track'
     shell:
-        'echo "warp_to_template(\'{input.ufile_nii}\',\'{input.connmap_3d}\'); exit;" | matlab -nodisplay -nosplash &> {log}'  
-
+        'mkdir -p {output.warped_dir} && cp -v {params.in_connmap} {output.warped_dir} && gunzip {output.warped_dir}/*.gz && ' #copy the connmaps to the warped folder and unzip them
+        'cp -v {input.ufile_nii} {params.ufile_nii} && ' # cp the ufile to the warped folder (so that dartel warped images get placed there too)
+        'parallel --jobs {threads} echo "warp_to_template(\'{params.ufile_nii}\',\'{{1}}\'); exit;" | matlab -nodisplay -nosplash &> {log} ::: {params.in_connmap}' #run jobs in parallel using all 32 cores
 
 
 rule save_connmap_template_npz:
     input:  
-        connmap_3d = expand('diffparc/sub-{subject}/probtrack_{template}_{seed}_{hemi}/wseeds_to_{target}_unzip.nii',target=targets,allow_missing=True),
-        mask = 'diffparc/template_masks/sub-{template}_hemi-{hemi}_desc-{seed}_mask.nii.gz'
+        mask = 'diffparc/template_masks/sub-{template}_hemi-{hemi}_desc-{seed}_mask.nii.gz',
+        warped_dir = 'diffparc/sub-{subject}/probtrack_{template}_{seed}_{hemi}_warped'
+    params:
+        connmap_3d = expand('diffparc/sub-{subject}/probtrack_{template}_{seed}_{hemi}_warped/wseeds_to_{target}.nii',target=targets,allow_missing=True),
     output:
         connmap_npz = 'diffparc/sub-{subject}/connmap/sub-{subject}_space-{template}_seed-{seed}_hemi-{hemi}_connMap.npz'
     log: 'logs/save_connmap_to_template_npz/sub-{subject}_{seed}_{hemi}_{template}.log'

--- a/config.yml
+++ b/config.yml
@@ -12,7 +12,7 @@ ufile_nii: sub-{subject}/u_rc1msub-{subject}_acq-procHCP_T1w_HCP3TUR100_template
 #segmentation in template space for defining groupwise masks (should be same structure as seeds)
 
 
-template: hcp_dartel
+template: hcpdartel
 template_seg_dir: /project/6007967/sudesnac/HCP/BF_ROIs/Zaborszky_2020_thresholded/HCPDARTELwarpped
 template_seg_nii: HCP_{hemi}_full{seed}_seed_temp.nii.gz
 

--- a/scripts/save_connmap_template_npz.py
+++ b/scripts/save_connmap_template_npz.py
@@ -6,9 +6,9 @@ mask_indices = mask_vol > 0
 masked = mask_vol[mask_indices]
 
 nvoxels = len(masked)
-ntargets = len(snakemake.input.connmap_3d)
+ntargets = len(snakemake.params.connmap_3d)
 conn = np.zeros((nvoxels,ntargets))
-for i,conn_file in enumerate(snakemake.input.connmap_3d):
+for i,conn_file in enumerate(snakemake.params.connmap_3d):
     vol = nib.load(conn_file).get_fdata()
     masked =  vol[mask_indices].T
     conn[:,i] = masked


### PR DESCRIPTION
-reworked rules to avoid splitting target
-analogous to PR#7 in zona-diffparc (https://github.com/akhanf/zona-diffparc/pull/7)
-also combined the ufile, gunzipping and transform into a single rule, and made that rule call matlab with gnu parallel to use 32 cores for transforming all targets
-currently testing, then will merge PR